### PR TITLE
fixed typo that hindered me from installing polymer-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ As you build out each chapter writing the markdown files of your own, you can bo
 12. Install Polymer.
 
     ```ps
-    npm install -g Polymer-cli
+    npm install -g polymer-cli
     ```
 
 ---


### PR DESCRIPTION
on macOS capital Polymer will not install but lowercase will